### PR TITLE
Update path to plugin jar in installation guide

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -640,4 +640,4 @@ Installation
   mvn clean package
 * Install the plugin: /path/to/elasticsearch/bin/plugin -install
   elasticsearch-inout-plugin -url
-  file:///$PWD/target/releases/elasticsearch-inout-plugin-$version.jar
+  file:///$PWD/target/elasticsearch-inout-plugin-$version.jar


### PR DESCRIPTION
on 'package' maven places jar under target dir and not under target/releases
