### PR TITLE
Scripting support - modify documents during reindex, query into, import

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,5 @@
 /target/
 /sandbox/
 /logs/
+/bin/
+/*.class

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>crate</groupId>
 	<artifactId>elasticsearch-inout-plugin</artifactId>
-	<version>0.5.0</version>
+	<version>0.6.0</version>
     <packaging>jar</packaging>
     <description>An Elasticsearch plugin which provides the ability to export and import data by query on server side.</description>
     <scm>
@@ -14,7 +14,7 @@
         <url>https://github.com/crate/elasticsearch-inout-plugin</url>
     </scm>
 	<properties>
-		<elasticsearch.version>0.90.3</elasticsearch.version>
+		<elasticsearch.version>1.0.0.beta1</elasticsearch.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 	<build>

--- a/src/main/java/crate/elasticsearch/action/export/AbstractTransportExportAction.java
+++ b/src/main/java/crate/elasticsearch/action/export/AbstractTransportExportAction.java
@@ -149,7 +149,7 @@ public abstract class AbstractTransportExportAction extends TransportBroadcastOp
         SearchShardTarget shardTarget = new SearchShardTarget(clusterService.localNode().id(), request.index(), request.shardId());
         ExportContext context = new ExportContext(0,
             new ShardSearchRequest().types(request.types()).filteringAliases(request.filteringAliases()),
-            shardTarget, indexShard.searcher(), indexService, indexShard, scriptService, cacheRecycler, nodePath);
+            shardTarget, indexShard.acquireSearcher("inout-plugin"), indexService, indexShard, scriptService, cacheRecycler, nodePath);
         ExportContext.setCurrent(context);
 
         try {

--- a/src/main/java/crate/elasticsearch/action/export/ExportContext.java
+++ b/src/main/java/crate/elasticsearch/action/export/ExportContext.java
@@ -10,6 +10,7 @@ import org.elasticsearch.index.service.IndexService;
 import org.elasticsearch.index.shard.service.IndexShard;
 import org.elasticsearch.script.ScriptService;
 import org.elasticsearch.search.SearchShardTarget;
+import org.elasticsearch.search.internal.DefaultSearchContext;
 import org.elasticsearch.search.internal.SearchContext;
 import org.elasticsearch.search.internal.ShardSearchRequest;
 
@@ -20,7 +21,7 @@ import java.util.List;
 /**
  * Container class for export specific informations.
  */
-public class ExportContext extends SearchContext {
+public class ExportContext extends DefaultSearchContext {
 
     private static final String VAR_SHARD = "${shard}";
     private static final String VAR_INDEX = "${index}";

--- a/src/main/java/crate/elasticsearch/action/export/ExportRequest.java
+++ b/src/main/java/crate/elasticsearch/action/export/ExportRequest.java
@@ -3,7 +3,6 @@ package crate.elasticsearch.action.export;
 import org.elasticsearch.action.ActionRequestValidationException;
 import org.elasticsearch.action.support.broadcast.BroadcastOperationRequest;
 import org.elasticsearch.common.Nullable;
-import org.elasticsearch.common.Required;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.bytes.BytesArray;
 import org.elasticsearch.common.bytes.BytesReference;
@@ -60,13 +59,11 @@ public class ExportRequest extends BroadcastOperationRequest<ExportRequest> {
         return source;
     }
 
-    @Required
     public ExportRequest source(String source) {
         return this.source(new BytesArray(source), false);
     }
 
 
-    @Required
     public ExportRequest source(BytesReference source, boolean unsafe) {
         this.source = source;
         this.querySourceUnsafe = unsafe;

--- a/src/main/java/crate/elasticsearch/action/import_/AbstractTransportImportAction.java
+++ b/src/main/java/crate/elasticsearch/action/import_/AbstractTransportImportAction.java
@@ -2,6 +2,8 @@ package crate.elasticsearch.action.import_;
 
 import crate.elasticsearch.action.import_.parser.IImportParser;
 import crate.elasticsearch.import_.Importer;
+import crate.elasticsearch.script.ScriptProvider;
+
 import org.elasticsearch.ElasticSearchException;
 import org.elasticsearch.action.FailedNodeException;
 import org.elasticsearch.action.support.nodes.TransportNodesOperationAction;
@@ -11,6 +13,7 @@ import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.env.NodeEnvironment;
+import org.elasticsearch.script.ScriptService;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.TransportService;
 
@@ -24,19 +27,28 @@ import static org.elasticsearch.common.collect.Lists.newArrayList;
 public abstract class AbstractTransportImportAction extends TransportNodesOperationAction<ImportRequest, ImportResponse, NodeImportRequest, NodeImportResponse>{
 
     private IImportParser importParser;
+    
+    private ScriptProvider scriptProvider;
 
     private Importer importer;
 
     private String nodePath = "";
+    
+    private final ScriptService scriptService;
 
     @Inject
     public AbstractTransportImportAction(Settings settings, ClusterName clusterName,
                                          ThreadPool threadPool, ClusterService clusterService,
-                                         TransportService transportService, IImportParser importParser, Importer importer, NodeEnvironment nodeEnv) {
+                                         TransportService transportService, 
+                                         ScriptService scriptService,
+                                         ScriptProvider scriptProvider, 
+                                         IImportParser importParser, 
+                                         Importer importer, NodeEnvironment nodeEnv) {
         super(settings, clusterName, threadPool, clusterService, transportService);
         this.importParser = importParser;
+        this.scriptProvider = scriptProvider;
         this.importer = importer;
-
+        this.scriptService=scriptService;
         File[] paths = nodeEnv.nodeDataLocations();
         if (paths.length > 0) {
             nodePath = paths[0].getAbsolutePath();
@@ -110,9 +122,9 @@ public abstract class AbstractTransportImportAction extends TransportNodesOperat
     protected NodeImportResponse nodeOperation(NodeImportRequest request)
             throws ElasticSearchException {
         ImportContext context = new ImportContext(nodePath);
-
         BytesReference source = request.source();
         importParser.parseSource(context, source);
+        scriptProvider.prepareContextForScriptExecution(context, scriptService);
         Importer.Result result = importer.execute(context, request);
         return new NodeImportResponse(clusterService.state().nodes().localNode(), result);
     }

--- a/src/main/java/crate/elasticsearch/action/import_/ImportContext.java
+++ b/src/main/java/crate/elasticsearch/action/import_/ImportContext.java
@@ -1,9 +1,15 @@
 package crate.elasticsearch.action.import_;
 
 import java.io.File;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.regex.Pattern;
 
-public class ImportContext {
+import org.elasticsearch.script.ExecutableScript;
+
+import crate.elasticsearch.script.IScriptContext;
+
+public class ImportContext implements IScriptContext{
 
     private String nodePath;
     private boolean compression;
@@ -11,12 +17,19 @@ public class ImportContext {
     private Pattern file_pattern;
     private boolean mappings = false;
     private boolean settings = false;
-
-    public ImportContext(String nodePath) {
+    private String scriptString;
+    private String scriptLang;
+    private Map<String, Object> scriptParams;
+    private Map<String, Object> executionContext;
+    private ExecutableScript executableScript;
+    
+	public ImportContext(String nodePath) {
+		super();
         this.nodePath = nodePath;
+        this.executionContext = new HashMap<String, Object>();
     }
 
-    public boolean compression() {
+	public boolean compression() {
         return compression;
     }
 
@@ -60,4 +73,59 @@ public class ImportContext {
     public void settings(boolean settings) {
         this.settings = settings;
     }
+    
+
+
+    @Override
+    public String scriptString() {
+        return scriptString;
+    }
+
+    @Override
+    public void scriptString(String scriptString) {
+        this.scriptString = scriptString;
+    }
+
+    @Override
+    public String scriptLang() {
+        return scriptLang;
+    }
+
+    @Override
+    public void scriptLang(String scriptLang) {
+        this.scriptLang = scriptLang;
+    }
+
+    @Override
+    public Map<String, Object> scriptParams() {
+        return scriptParams;
+    }
+
+    @Override
+    public void scriptParams(Map<String, Object> scriptParams) {
+        this.scriptParams = scriptParams;
+    }
+
+   
+    @Override
+    public void executableScript(ExecutableScript executableScript) {
+        this.executableScript = executableScript;
+    }
+
+   
+    @Override
+    public void executionContext(Map<String, Object> executionContext) {
+        this.executionContext = executionContext;
+    }
+
+    @Override
+	public Map<String, Object> executionContext() {
+		return executionContext;
+	}
+
+    @Override
+	public ExecutableScript executableScript() {
+		return executableScript;
+	}
+    
 }

--- a/src/main/java/crate/elasticsearch/action/import_/ImportRequest.java
+++ b/src/main/java/crate/elasticsearch/action/import_/ImportRequest.java
@@ -1,7 +1,6 @@
 package crate.elasticsearch.action.import_;
 
 import org.elasticsearch.action.support.nodes.NodesOperationRequest;
-import org.elasticsearch.common.Required;
 import org.elasticsearch.common.bytes.BytesArray;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.io.stream.StreamInput;
@@ -32,12 +31,10 @@ public class ImportRequest extends NodesOperationRequest<ImportRequest> {
         return source;
     }
 
-    @Required
     public ImportRequest source(String source) {
         return this.source(new BytesArray(source), false);
     }
 
-    @Required
     public ImportRequest source(BytesReference source, boolean unsafe) {
         this.source = source;
         return this;

--- a/src/main/java/crate/elasticsearch/action/import_/NodeImportResponse.java
+++ b/src/main/java/crate/elasticsearch/action/import_/NodeImportResponse.java
@@ -39,6 +39,9 @@ public class NodeImportResponse extends NodeOperationResponse implements ToXCont
             if (counts.invalid > 0) {
                 builder.field(Fields.INVALIDATED, counts.invalid);
             }
+            if (counts.deletes > 0) {
+                builder.field(Fields.DELETES, counts.deletes);
+            }
             builder.endObject();
         }
         builder.endArray();
@@ -58,6 +61,7 @@ public class NodeImportResponse extends NodeOperationResponse implements ToXCont
             counts.successes = in.readInt();
             counts.failures = in.readInt();
             counts.invalid = in.readInt();
+            counts.deletes = in.readInt();
             result.importCounts.add(counts);
         }
     }
@@ -72,6 +76,7 @@ public class NodeImportResponse extends NodeOperationResponse implements ToXCont
             out.writeInt(counts.successes);
             out.writeInt(counts.failures);
             out.writeInt(counts.invalid);
+            out.writeInt(counts.deletes);
         }
     }
 
@@ -89,5 +94,6 @@ public class NodeImportResponse extends NodeOperationResponse implements ToXCont
         static final XContentBuilderString SUCCESSES = new XContentBuilderString("successes");
         static final XContentBuilderString FAILURES = new XContentBuilderString("failures");
         static final XContentBuilderString INVALIDATED = new XContentBuilderString("invalidated");
+        static final XContentBuilderString DELETES = new XContentBuilderString("deletes");
     }
 }

--- a/src/main/java/crate/elasticsearch/action/import_/TransportImportAction.java
+++ b/src/main/java/crate/elasticsearch/action/import_/TransportImportAction.java
@@ -2,11 +2,14 @@ package crate.elasticsearch.action.import_;
 
 import crate.elasticsearch.action.import_.parser.ImportParser;
 import crate.elasticsearch.import_.Importer;
+import crate.elasticsearch.script.ScriptProvider;
+
 import org.elasticsearch.cluster.ClusterName;
 import org.elasticsearch.cluster.ClusterService;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.env.NodeEnvironment;
+import org.elasticsearch.script.ScriptService;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.TransportService;
 
@@ -18,8 +21,8 @@ public class TransportImportAction extends AbstractTransportImportAction {
     @Inject
     public TransportImportAction(Settings settings, ClusterName clusterName,
                                          ThreadPool threadPool, ClusterService clusterService,
-                                         TransportService transportService, ImportParser importParser, Importer importer, NodeEnvironment nodeEnv) {
-        super(settings, clusterName, threadPool, clusterService, transportService, importParser, importer, nodeEnv);
+                                         TransportService transportService, ScriptService scriptService, ScriptProvider scriptProvider, ImportParser importParser, Importer importer, NodeEnvironment nodeEnv) {
+        super(settings, clusterName, threadPool, clusterService, transportService, scriptService, scriptProvider, importParser, importer, nodeEnv);
     }
 
     @Override

--- a/src/main/java/crate/elasticsearch/action/reindex/ReindexParser.java
+++ b/src/main/java/crate/elasticsearch/action/reindex/ReindexParser.java
@@ -15,6 +15,7 @@ import org.elasticsearch.search.query.QueryPhase;
 import crate.elasticsearch.action.searchinto.SearchIntoContext;
 import crate.elasticsearch.action.searchinto.parser.AbstractSearchIntoParser;
 import crate.elasticsearch.action.searchinto.parser.ISearchIntoParser;
+import crate.elasticsearch.script.ScriptParser;
 
 /**
  * Parser for pay load given to _reindex action.
@@ -22,9 +23,9 @@ import crate.elasticsearch.action.searchinto.parser.ISearchIntoParser;
 public class ReindexParser extends AbstractSearchIntoParser implements ISearchIntoParser {
 
     private final ImmutableMap<String, SearchParseElement> elementParsers;
-
     @Inject
-    public ReindexParser(QueryPhase queryPhase, FetchPhase fetchPhase) {
+    public ReindexParser(QueryPhase queryPhase, FetchPhase fetchPhase, ScriptParser scriptParser) {
+    	super(scriptParser);
         Map<String, SearchParseElement> elementParsers = new HashMap<String,
                 SearchParseElement>();
         elementParsers.putAll(queryPhase.parseElements());
@@ -39,7 +40,7 @@ public class ReindexParser extends AbstractSearchIntoParser implements ISearchIn
 
     @Override
     public void parseSource(SearchIntoContext context, BytesReference source)
-            throws SearchParseException {
+            throws SearchParseException {    
         context.fieldNames().add("_id");
         context.fieldNames().add("_source");
         context.outputNames().put("_id", "_id");

--- a/src/main/java/crate/elasticsearch/action/reindex/TransportReindexAction.java
+++ b/src/main/java/crate/elasticsearch/action/reindex/TransportReindexAction.java
@@ -10,6 +10,7 @@ import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.TransportService;
 
 import crate.elasticsearch.action.searchinto.AbstractTransportSearchIntoAction;
+import crate.elasticsearch.script.ScriptProvider;
 import crate.elasticsearch.searchinto.Writer;
 
 public class TransportReindexAction extends AbstractTransportSearchIntoAction {
@@ -18,9 +19,9 @@ public class TransportReindexAction extends AbstractTransportSearchIntoAction {
     public TransportReindexAction(Settings settings, ThreadPool threadPool,
             ClusterService clusterService, TransportService transportService, CacheRecycler cacheRecycler,
             IndicesService indicesService, ScriptService scriptService,
-            ReindexParser parser, Writer writer) {
+            ScriptProvider scriptProvider, ReindexParser parser, Writer writer) {
         super(settings, threadPool, clusterService, transportService, cacheRecycler, indicesService,
-                scriptService, parser, writer);
+                scriptService, scriptProvider, parser, writer);
     }
 
     @Override

--- a/src/main/java/crate/elasticsearch/action/restore/TransportRestoreAction.java
+++ b/src/main/java/crate/elasticsearch/action/restore/TransportRestoreAction.java
@@ -3,11 +3,14 @@ package crate.elasticsearch.action.restore;
 import crate.elasticsearch.action.import_.AbstractTransportImportAction;
 import crate.elasticsearch.action.restore.parser.RestoreParser;
 import crate.elasticsearch.import_.Importer;
+import crate.elasticsearch.script.ScriptProvider;
+
 import org.elasticsearch.cluster.ClusterName;
 import org.elasticsearch.cluster.ClusterService;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.env.NodeEnvironment;
+import org.elasticsearch.script.ScriptService;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.TransportService;
 
@@ -19,8 +22,8 @@ public class TransportRestoreAction extends AbstractTransportImportAction {
     @Inject
     public TransportRestoreAction(Settings settings, ClusterName clusterName,
                                   ThreadPool threadPool, ClusterService clusterService,
-                                  TransportService transportService, RestoreParser restoreParser, Importer importer, NodeEnvironment nodeEnv) {
-        super(settings, clusterName, threadPool, clusterService, transportService, restoreParser, importer, nodeEnv);
+                                  TransportService transportService, ScriptService scriptService, ScriptProvider scriptProvider, RestoreParser restoreParser, Importer importer, NodeEnvironment nodeEnv) {
+        super(settings, clusterName, threadPool, clusterService, transportService, scriptService, scriptProvider, restoreParser, importer, nodeEnv);
     }
 
     @Override

--- a/src/main/java/crate/elasticsearch/action/searchinto/AbstractTransportSearchIntoAction.java
+++ b/src/main/java/crate/elasticsearch/action/searchinto/AbstractTransportSearchIntoAction.java
@@ -33,9 +33,8 @@ import org.elasticsearch.search.internal.ShardSearchRequest;
 import org.elasticsearch.search.query.QueryPhaseExecutionException;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.TransportService;
-
 import crate.elasticsearch.action.searchinto.parser.ISearchIntoParser;
-import crate.elasticsearch.action.searchinto.parser.SearchIntoParser;
+import crate.elasticsearch.script.ScriptProvider;
 import crate.elasticsearch.searchinto.Writer;
 import crate.elasticsearch.searchinto.WriterResult;
 
@@ -51,6 +50,8 @@ public abstract class AbstractTransportSearchIntoAction extends
     private final IndicesService indicesService;
 
     private final ScriptService scriptService;
+    
+    private ScriptProvider scriptProvider;
 
     private final ISearchIntoParser parser;
 
@@ -63,11 +64,13 @@ public abstract class AbstractTransportSearchIntoAction extends
             ThreadPool threadPool, ClusterService clusterService,
             TransportService transportService, CacheRecycler cacheRecycler,
             IndicesService indicesService, ScriptService scriptService,
+            ScriptProvider scriptProvider,
             ISearchIntoParser parser, Writer writer) {
         super(settings, threadPool, clusterService, transportService);
         this.indicesService = indicesService;
         this.cacheRecycler = cacheRecycler;
         this.scriptService = scriptService;
+        this.scriptProvider = scriptProvider;
         this.parser = parser;
         this.writer = writer;
     }
@@ -171,10 +174,11 @@ public abstract class AbstractTransportSearchIntoAction extends
             shardTarget, indexShard.acquireSearcher("inout-plugin"), indexService, indexShard, scriptService, cacheRecycler
         );
         SearchIntoContext.setCurrent(context);
-
         try {
             BytesReference source = request.source();
             parser.parseSource(context, source);
+            scriptProvider.prepareContextForScriptExecution(context, scriptService);
+            
             context.preProcess();
             try {
                 if (context.explain()) {

--- a/src/main/java/crate/elasticsearch/action/searchinto/AbstractTransportSearchIntoAction.java
+++ b/src/main/java/crate/elasticsearch/action/searchinto/AbstractTransportSearchIntoAction.java
@@ -168,7 +168,7 @@ public abstract class AbstractTransportSearchIntoAction extends
                 request.shardId());
         SearchIntoContext context = new SearchIntoContext(0,
             new ShardSearchRequest().types(request.types()).filteringAliases(request.filteringAliases()),
-            shardTarget, indexShard.searcher(), indexService, indexShard, scriptService, cacheRecycler
+            shardTarget, indexShard.acquireSearcher("inout-plugin"), indexService, indexShard, scriptService, cacheRecycler
         );
         SearchIntoContext.setCurrent(context);
 

--- a/src/main/java/crate/elasticsearch/action/searchinto/SearchIntoContext.java
+++ b/src/main/java/crate/elasticsearch/action/searchinto/SearchIntoContext.java
@@ -7,10 +7,13 @@ import org.elasticsearch.common.transport.InetSocketTransportAddress;
 import org.elasticsearch.index.engine.Engine;
 import org.elasticsearch.index.service.IndexService;
 import org.elasticsearch.index.shard.service.IndexShard;
+import org.elasticsearch.script.ExecutableScript;
 import org.elasticsearch.script.ScriptService;
 import org.elasticsearch.search.SearchShardTarget;
 import org.elasticsearch.search.internal.DefaultSearchContext;
 import org.elasticsearch.search.internal.ShardSearchRequest;
+
+import crate.elasticsearch.script.IScriptContext;
 
 import java.util.HashMap;
 import java.util.List;
@@ -19,13 +22,19 @@ import java.util.Map;
 /**
  * Container class for inout specific informations.
  */
-public class SearchIntoContext extends DefaultSearchContext {
+public class SearchIntoContext extends DefaultSearchContext implements IScriptContext {
 
     // currently we only support index targets
     private String targetType = "index";
 
     private List<InetSocketTransportAddress> targetNodes;
 
+    private String scriptString;
+    private String scriptLang;
+    private Map<String, Object> scriptParams;
+    private Map<String, Object> executionContext;
+    private ExecutableScript executableScript;
+    
 
     public Map<String, String> outputNames() {
         return outputNames;
@@ -40,6 +49,7 @@ public class SearchIntoContext extends DefaultSearchContext {
             ScriptService scriptService, CacheRecycler cacheRecycler) {
         super(id, request, shardTarget, engineSearcher, indexService,
                 indexShard, scriptService, cacheRecycler);
+        this.executionContext = new HashMap<String, Object>();
     }
 
     public String targetType() {
@@ -57,5 +67,59 @@ public class SearchIntoContext extends DefaultSearchContext {
     public void emptyTargetNodes() {
         this.targetNodes = ImmutableList.of();
     }
+
+    @Override
+    public String scriptString() {
+        return scriptString;
+    }
+
+    @Override
+    public void scriptString(String scriptString) {
+        this.scriptString = scriptString;
+    }
+
+    @Override
+    public String scriptLang() {
+        return scriptLang;
+    }
+
+    @Override
+    public void scriptLang(String scriptLang) {
+        this.scriptLang = scriptLang;
+    }
+
+    @Override
+    public Map<String, Object> scriptParams() {
+        return scriptParams;
+    }
+
+    @Override
+    public void scriptParams(Map<String, Object> scriptParams) {
+        this.scriptParams = scriptParams;
+    }
+
+   
+    @Override
+    public void executableScript(ExecutableScript executableScript) {
+        this.executableScript = executableScript;
+    }
+
+   
+    @Override
+    public void executionContext(Map<String, Object> executionContext) {
+        this.executionContext = executionContext;
+    }
+
+    @Override
+	public Map<String, Object> executionContext() {
+		return executionContext;
+	}
+
+    @Override
+	public ExecutableScript executableScript() {
+		return executableScript;
+	}
+    
+    
 
 }

--- a/src/main/java/crate/elasticsearch/action/searchinto/SearchIntoContext.java
+++ b/src/main/java/crate/elasticsearch/action/searchinto/SearchIntoContext.java
@@ -9,7 +9,7 @@ import org.elasticsearch.index.service.IndexService;
 import org.elasticsearch.index.shard.service.IndexShard;
 import org.elasticsearch.script.ScriptService;
 import org.elasticsearch.search.SearchShardTarget;
-import org.elasticsearch.search.internal.SearchContext;
+import org.elasticsearch.search.internal.DefaultSearchContext;
 import org.elasticsearch.search.internal.ShardSearchRequest;
 
 import java.util.HashMap;
@@ -19,7 +19,7 @@ import java.util.Map;
 /**
  * Container class for inout specific informations.
  */
-public class SearchIntoContext extends SearchContext {
+public class SearchIntoContext extends DefaultSearchContext {
 
     // currently we only support index targets
     private String targetType = "index";

--- a/src/main/java/crate/elasticsearch/action/searchinto/SearchIntoRequest.java
+++ b/src/main/java/crate/elasticsearch/action/searchinto/SearchIntoRequest.java
@@ -3,7 +3,6 @@ package crate.elasticsearch.action.searchinto;
 import org.elasticsearch.action.ActionRequestValidationException;
 import org.elasticsearch.action.support.broadcast.BroadcastOperationRequest;
 import org.elasticsearch.common.Nullable;
-import org.elasticsearch.common.Required;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.bytes.BytesArray;
 import org.elasticsearch.common.bytes.BytesReference;
@@ -63,13 +62,11 @@ public class SearchIntoRequest extends
         return source;
     }
 
-    @Required
     public SearchIntoRequest source(String source) {
         return this.source(new BytesArray(source), false);
     }
 
 
-    @Required
     public SearchIntoRequest source(BytesReference source, boolean unsafe) {
         this.source = source;
         this.querySourceUnsafe = unsafe;

--- a/src/main/java/crate/elasticsearch/action/searchinto/TransportSearchIntoAction.java
+++ b/src/main/java/crate/elasticsearch/action/searchinto/TransportSearchIntoAction.java
@@ -10,6 +10,7 @@ import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.TransportService;
 
 import crate.elasticsearch.action.searchinto.parser.SearchIntoParser;
+import crate.elasticsearch.script.ScriptProvider;
 import crate.elasticsearch.searchinto.Writer;
 
 
@@ -23,9 +24,10 @@ public class TransportSearchIntoAction extends AbstractTransportSearchIntoAction
             ThreadPool threadPool, ClusterService clusterService,
             TransportService transportService, CacheRecycler cacheRecycler,
             IndicesService indicesService, ScriptService scriptService,
+            ScriptProvider scriptProvider,
             SearchIntoParser parser, Writer writer) {
         super(settings, threadPool, clusterService, transportService, cacheRecycler, indicesService,
-            scriptService, parser, writer);
+            scriptService, scriptProvider, parser, writer);
     }
 
     @Override

--- a/src/main/java/crate/elasticsearch/action/searchinto/parser/SearchIntoParser.java
+++ b/src/main/java/crate/elasticsearch/action/searchinto/parser/SearchIntoParser.java
@@ -3,6 +3,7 @@ package crate.elasticsearch.action.searchinto.parser;
 import java.util.HashMap;
 import java.util.Map;
 
+import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.collect.ImmutableMap;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.index.mapper.FieldMapper;
@@ -13,6 +14,7 @@ import org.elasticsearch.search.fetch.explain.ExplainParseElement;
 import org.elasticsearch.search.query.QueryPhase;
 
 import crate.elasticsearch.action.searchinto.SearchIntoContext;
+import crate.elasticsearch.script.ScriptParser;
 
 /**
  * Parser for payload given to _search_into action.
@@ -20,9 +22,11 @@ import crate.elasticsearch.action.searchinto.SearchIntoContext;
 public class SearchIntoParser extends AbstractSearchIntoParser implements ISearchIntoParser {
 
     private final ImmutableMap<String, SearchParseElement> elementParsers;
+    
 
     @Inject
-    public SearchIntoParser(QueryPhase queryPhase, FetchPhase fetchPhase) {
+    public SearchIntoParser(QueryPhase queryPhase, FetchPhase fetchPhase, ScriptParser scriptParser) {
+    	super(scriptParser);
         Map<String, SearchParseElement> elementParsers = new HashMap<String,
                 SearchParseElement>();
         elementParsers.putAll(queryPhase.parseElements());
@@ -57,5 +61,10 @@ public class SearchIntoParser extends AbstractSearchIntoParser implements ISearc
         return elementParsers;
     }
 
+    @Override
+    public void parseSource(SearchIntoContext context, BytesReference source)
+            throws SearchParseException {
+        super.parseSource(context, source);
+    }
 
 }

--- a/src/main/java/crate/elasticsearch/export/ExportCollector.java
+++ b/src/main/java/crate/elasticsearch/export/ExportCollector.java
@@ -15,6 +15,7 @@ import org.apache.lucene.index.IndexReader;
 import org.apache.lucene.search.Collector;
 import org.apache.lucene.search.Scorer;
 import org.elasticsearch.common.bytes.BytesReference;
+import org.elasticsearch.common.io.Streams;
 import org.elasticsearch.common.io.stream.BytesStreamOutput;
 import org.elasticsearch.common.text.StringAndBytesText;
 import org.elasticsearch.common.text.Text;
@@ -171,12 +172,9 @@ public class ExportCollector extends Collector {
 
         searchHit.shardTarget(context.shardTarget());
         exportFields.hit(searchHit);
-        BytesStreamOutput os = new BytesStreamOutput();
-        XContentBuilder builder = new XContentBuilder(XContentFactory.xContent(XContentType.JSON), os);
+        XContentBuilder builder = new XContentBuilder(XContentFactory.xContent(XContentType.JSON), out);
         exportFields.toXContent(builder, ToXContent.EMPTY_PARAMS);
         builder.flush();
-        BytesReference bytes = os.bytes();
-        out.write(bytes.array(), bytes.arrayOffset(), bytes.length());
         out.write('\n');
         out.flush();
         numExported++;

--- a/src/main/java/crate/elasticsearch/export/ExportCollector.java
+++ b/src/main/java/crate/elasticsearch/export/ExportCollector.java
@@ -23,15 +23,13 @@ import org.elasticsearch.common.xcontent.ToXContent;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentFactory;
 import org.elasticsearch.common.xcontent.XContentType;
-import org.elasticsearch.index.fieldvisitor.CustomFieldsVisitor;
-import org.elasticsearch.index.fieldvisitor.FieldsVisitor;
-import org.elasticsearch.index.fieldvisitor.JustUidFieldsVisitor;
-import org.elasticsearch.index.fieldvisitor.UidAndSourceFieldsVisitor;
+import org.elasticsearch.index.fieldvisitor.*;
 import org.elasticsearch.index.mapper.DocumentMapper;
 import org.elasticsearch.index.mapper.FieldMappers;
 import org.elasticsearch.index.mapper.internal.SourceFieldMapper;
 import org.elasticsearch.search.SearchHitField;
 import org.elasticsearch.search.fetch.FetchSubPhase;
+import org.elasticsearch.search.fetch.source.FetchSourceContext;
 import org.elasticsearch.search.internal.InternalSearchHit;
 import org.elasticsearch.search.internal.InternalSearchHitField;
 
@@ -62,17 +60,21 @@ public class ExportCollector extends Collector {
 
         if (!context.hasFieldNames()) {
             if (context.hasPartialFields()) {
-                // partial fields need the source, so fetch it, but don't return it
+                // partial fields need the source, so fetch it
                 fieldsVisitor = new UidAndSourceFieldsVisitor();
-            } else if (context.hasScriptFields()) {
-                // we ask for script fields, and no field names, don't load the source
-                fieldsVisitor = new JustUidFieldsVisitor();
             } else {
-                sourceRequested = true;
-                fieldsVisitor = new UidAndSourceFieldsVisitor();
+                // no fields specified, default to return source if no explicit indication
+                if (!context.hasScriptFields() && !context.hasFetchSourceContext()) {
+                    context.fetchSourceContext(new FetchSourceContext(true));
+                }
+                fieldsVisitor = context.sourceRequested() ? new UidAndSourceFieldsVisitor() : new JustUidFieldsVisitor();
             }
         } else if (context.fieldNames().isEmpty()) {
-            fieldsVisitor = new JustUidFieldsVisitor();
+            if (context.sourceRequested()) {
+                fieldsVisitor = new UidAndSourceFieldsVisitor();
+            } else {
+                fieldsVisitor = new JustUidFieldsVisitor();
+            }
         } else {
             boolean loadAllStored = false;
             Set<String> fieldNames = null;
@@ -82,7 +84,11 @@ public class ExportCollector extends Collector {
                     continue;
                 }
                 if (fieldName.equals(SourceFieldMapper.NAME)) {
-                    sourceRequested = true;
+                    if (context.hasFetchSourceContext()) {
+                        context.fetchSourceContext().fetchSource(true);
+                    } else {
+                        context.fetchSourceContext(new FetchSourceContext(true));
+                    }
                     continue;
                 }
                 FieldMappers x = context.smartNameFieldMappers
@@ -100,15 +106,11 @@ public class ExportCollector extends Collector {
                 }
             }
             if (loadAllStored) {
-                if (sourceRequested || extractFieldNames != null) {
-                    fieldsVisitor = new CustomFieldsVisitor(true, true); // load everything, including _source
-                } else {
-                    fieldsVisitor = new CustomFieldsVisitor(true, false);
-                }
+                fieldsVisitor = new AllFieldsVisitor(); // load everything, including _source
             } else if (fieldNames != null) {
-                boolean loadSource = extractFieldNames != null || sourceRequested;
+                boolean loadSource = extractFieldNames != null || context.sourceRequested();
                 fieldsVisitor = new CustomFieldsVisitor(fieldNames, loadSource);
-            } else if (extractFieldNames != null || sourceRequested) {
+            } else if (extractFieldNames != null || context.sourceRequested()) {
                 fieldsVisitor = new UidAndSourceFieldsVisitor();
             } else {
                 fieldsVisitor = new JustUidFieldsVisitor();
@@ -159,8 +161,8 @@ public class ExportCollector extends Collector {
 
         InternalSearchHit searchHit = new InternalSearchHit(doc,
                 fieldsVisitor.uid().id(), typeText,
-                sourceRequested ? fieldsVisitor.source() : null,
-                searchFields);
+                searchFields).sourceRef(fieldsVisitor.source());
+
 
         for (FetchSubPhase fetchSubPhase : fetchSubPhases) {
             FetchSubPhase.HitContext hitContext = new FetchSubPhase.HitContext();

--- a/src/main/java/crate/elasticsearch/import_/ImportBulkListener.java
+++ b/src/main/java/crate/elasticsearch/import_/ImportBulkListener.java
@@ -33,6 +33,10 @@ public class ImportBulkListener extends BaseFuture<ImportBulkListener> implement
         counts.failures++;
     }
 
+    public void addDelete() {
+        counts.deletes++;
+    }
+
     public ImportCounts importCounts() {
         return counts;
     }

--- a/src/main/java/crate/elasticsearch/import_/Importer.java
+++ b/src/main/java/crate/elasticsearch/import_/Importer.java
@@ -21,6 +21,7 @@ import java.util.regex.Pattern;
 import java.util.zip.GZIPInputStream;
 
 import org.elasticsearch.ElasticSearchException;
+import org.elasticsearch.ElasticSearchIllegalArgumentException;
 import org.elasticsearch.ElasticSearchParseException;
 import org.elasticsearch.action.admin.cluster.state.ClusterStateRequest;
 import org.elasticsearch.action.admin.cluster.state.ClusterStateResponse;
@@ -33,6 +34,7 @@ import org.elasticsearch.client.Client;
 import org.elasticsearch.client.Requests;
 import org.elasticsearch.cluster.metadata.IndexMetaData;
 import org.elasticsearch.common.collect.ImmutableMap;
+import org.elasticsearch.common.collect.Tuple;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.inject.Injector;
 import org.elasticsearch.common.settings.ImmutableSettings;
@@ -43,6 +45,7 @@ import org.elasticsearch.common.unit.ByteSizeValue;
 import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentFactory;
+import org.elasticsearch.common.xcontent.XContentHelper;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.common.xcontent.XContentParser.Token;
 import org.elasticsearch.common.xcontent.XContentType;
@@ -62,6 +65,8 @@ import crate.elasticsearch.action.import_.NodeImportRequest;
 
 public class Importer {
 
+
+	
     private Client client;
     private final Injector injector;
 
@@ -130,7 +135,7 @@ public class Importer {
             for (File file : files) {
                 String fileName = file.getName();
                 if (!fileName.endsWith(".mapping") && !fileName.endsWith(".settings")) {
-                    ImportCounts counts = handleFile(file, index, type, bulkSize, context.compression());
+                    ImportCounts counts = handleFile(file, index, type, bulkSize, context);
                     if (counts != null) {
                         result.importCounts.add(counts);
                     }
@@ -141,7 +146,7 @@ public class Importer {
         return result;
     }
 
-    private ImportCounts handleFile(File file, String index, String type, int bulkSize, boolean compression) {
+    private ImportCounts handleFile(File file, String index, String type, int bulkSize, ImportContext context) {
         if (file.isFile() && file.canRead()) {
             ImportBulkListener bulkListener = new ImportBulkListener(file.getAbsolutePath());
             BulkProcessor bulkProcessor = BulkProcessor.builder(client, bulkListener)
@@ -152,7 +157,7 @@ public class Importer {
                     .build();
             try {
                 BufferedReader r;
-                if (compression) {
+                if (context.compression()) {
                     GZIPInputStream is = new GZIPInputStream(new FileInputStream(file));
                     r = new BufferedReader(new InputStreamReader(is));
                 } else {
@@ -162,27 +167,32 @@ public class Importer {
                 while ((line = r.readLine()) != null) {
                     IndexRequest indexRequest;
                     try {
-                        indexRequest = parseObject(line);
+                        indexRequest = parseObject(line, context);
+                        if (indexRequest == null) {
+                            bulkListener.addDelete();
+                            continue;
+                        }
+                    } catch (ExpiredObjectException e) {
+                        bulkListener.addInvalid();
+                        continue;
                     } catch (ObjectImportException e) {
                         bulkListener.addFailure();
                         continue;
                     }
-                    if (indexRequest != null) {
-                        indexRequest.opType(OpType.INDEX);
-                        if (index != null) {
-                            indexRequest.index(index);
-                        }
-                        if (type != null) {
-                            indexRequest.type(type);
-                        }
-                        if (indexRequest.type() != null && indexRequest.index() != null) {
-                            bulkProcessor.add(indexRequest);
-                        } else {
-                            bulkListener.addFailure();
-                        }
-                    } else {
-                        bulkListener.addInvalid();
+
+                    indexRequest.opType(OpType.INDEX);
+                    if (index != null) {
+                        indexRequest.index(index);
                     }
+                    if (type != null) {
+                        indexRequest.type(type);
+                    }
+                    if (indexRequest.type() != null && indexRequest.index() != null) {
+                        bulkProcessor.add(indexRequest);
+                    } else {
+                        bulkListener.addFailure();
+                    }
+
                 }
             } catch (FileNotFoundException e) {
                 // Ignore not existing files, actually they should exist, as they are filtered before.
@@ -200,7 +210,7 @@ public class Importer {
         return null;
     }
 
-    private IndexRequest parseObject(String line) throws ObjectImportException {
+    private IndexRequest parseObject(String line, ImportContext importContext) throws ObjectImportException, ExpiredObjectException {
         XContentParser parser = null;
         try {
             IndexRequest indexRequest = new IndexRequest();
@@ -247,10 +257,64 @@ public class Importer {
                     indexRequest.ttl(ttl);
                 } else {
                     // object is invalid, do not import
-                    return null;
+                    throw new ExpiredObjectException();
                 }
             }
-            indexRequest.source(sourceBuilder);
+            
+            if(importContext.scriptString()!=null){
+                Tuple<XContentType, Map<String, Object>> sourceAndContent = XContentHelper.convertToMap(sourceBuilder.bytes(), true);
+                importContext.executionContext().clear();
+                importContext.executionContext().put("_index", indexRequest.index());
+                importContext.executionContext().put("_type", indexRequest.type());
+                importContext.executionContext().put("_id", indexRequest.id());
+                importContext.executionContext().put("_version", indexRequest.version());
+                importContext.executionContext().put("_source", sourceAndContent.v2());
+                importContext.executionContext().put("_routing", indexRequest.routing());
+                importContext.executionContext().put("_parent", indexRequest.parent());
+                importContext.executionContext().put("_timestamp", indexRequest.timestamp());
+                importContext.executionContext().put("_ttl", indexRequest.ttl());
+
+                try {
+                    importContext.executableScript().setNextVar("ctx", importContext.executionContext());
+                    importContext.executableScript().run();
+                    // we need to unwrap the ctx...
+                    importContext.executionContext().putAll((Map<String, Object>) importContext.executableScript().unwrap(importContext.executionContext()));
+                    indexRequest.source(sourceAndContent.v2());
+
+                    String operation = (String) importContext.executionContext().get("op");
+                    if (!(operation == null || "index".equals(operation)))  {
+                        return null;
+                    }
+
+                    Object fetchedTimestamp = importContext.executionContext().get("_timestamp");
+                    if (fetchedTimestamp != null) {
+                        if (fetchedTimestamp instanceof String) {
+                            indexRequest.timestamp(String.valueOf(TimeValue.parseTimeValue((String) fetchedTimestamp, null).millis()));
+                        } else {
+                            indexRequest.timestamp(fetchedTimestamp.toString());
+                        }
+                    }
+                    Object fetchedTTL = importContext.executionContext().get("_ttl");
+                    if (fetchedTTL != null) {
+                        Long newTtl = -1L;
+                        if (fetchedTTL instanceof Number) {
+                             newTtl = ((Number) fetchedTTL).longValue();
+
+                        } else {
+                            newTtl = TimeValue.parseTimeValue((String) fetchedTTL, null).millis();
+                        }
+                        if (newTtl > 0) {
+                            indexRequest.ttl(newTtl);
+                        }
+                    }
+
+                } catch (Exception e) {
+                    throw new ElasticSearchIllegalArgumentException("failed to execute script", e);
+                }
+               } else {
+                   indexRequest.source(sourceBuilder);
+                }
+
             return indexRequest;
         } catch (ElasticSearchParseException e) {
             throw new ObjectImportException(e);
@@ -423,6 +487,15 @@ public class Importer {
         }
    }
 
+    class ExpiredObjectException extends ElasticSearchException {
+
+        private static final long serialVersionUID = 2445764408399929056L;
+
+        public ExpiredObjectException() {
+            super("Object TTL expired, could not be imported.");
+        }
+    }
+
     public static class Result {
         public List<ImportCounts> importCounts = new ArrayList<Importer.ImportCounts>();
         public long took;
@@ -433,6 +506,7 @@ public class Importer {
         public int successes = 0;
         public int failures = 0;
         public int invalid = 0;
+        public int deletes = 0;
     }
 
 }

--- a/src/main/java/crate/elasticsearch/rest/action/admin/export/RestExportAction.java
+++ b/src/main/java/crate/elasticsearch/rest/action/admin/export/RestExportAction.java
@@ -3,7 +3,6 @@ package crate.elasticsearch.rest.action.admin.export;
 import static org.elasticsearch.rest.RestRequest.Method.POST;
 import static org.elasticsearch.rest.RestStatus.BAD_REQUEST;
 import static org.elasticsearch.rest.RestStatus.OK;
-import static org.elasticsearch.rest.action.support.RestActions.splitTypes;
 
 import java.io.IOException;
 
@@ -12,6 +11,7 @@ import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.support.IgnoreIndices;
 import org.elasticsearch.action.support.broadcast.BroadcastOperationThreading;
 import org.elasticsearch.client.Client;
+import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.settings.Settings;
@@ -52,7 +52,7 @@ public class RestExportAction extends BaseRestHandler {
     }
 
     public void handleRequest(final RestRequest request, final RestChannel channel) {
-        ExportRequest exportRequest = new ExportRequest(RestActions.splitIndices(request.param("index")));
+        ExportRequest exportRequest = new ExportRequest(Strings.splitStringByCommaToArray(request.param("index")));
 
         if (request.hasParam("ignore_indices")) {
             exportRequest.ignoreIndices(IgnoreIndices.fromString(request.param("ignore_indices")));
@@ -79,7 +79,7 @@ public class RestExportAction extends BaseRestHandler {
                 }
             }
             exportRequest.routing(request.param("routing"));
-            exportRequest.types(splitTypes(request.param("type")));
+            exportRequest.types(Strings.splitStringByCommaToArray(request.param("type")));
             exportRequest.preference(request.param("preference", "_primary"));
         } catch (Exception e) {
             try {

--- a/src/main/java/crate/elasticsearch/rest/action/admin/searchinto/RestSearchIntoAction.java
+++ b/src/main/java/crate/elasticsearch/rest/action/admin/searchinto/RestSearchIntoAction.java
@@ -3,7 +3,6 @@ package crate.elasticsearch.rest.action.admin.searchinto;
 import static org.elasticsearch.rest.RestRequest.Method.POST;
 import static org.elasticsearch.rest.RestStatus.BAD_REQUEST;
 import static org.elasticsearch.rest.RestStatus.OK;
-import static org.elasticsearch.rest.action.support.RestActions.splitTypes;
 
 import java.io.IOException;
 
@@ -12,6 +11,7 @@ import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.support.IgnoreIndices;
 import org.elasticsearch.action.support.broadcast.BroadcastOperationThreading;
 import org.elasticsearch.client.Client;
+import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.settings.Settings;
@@ -55,7 +55,7 @@ public class RestSearchIntoAction extends BaseRestHandler {
     public void handleRequest(final RestRequest request,
             final RestChannel channel) {
         SearchIntoRequest searchIntoRequest = new SearchIntoRequest(
-                RestActions.splitIndices(request.param("index")));
+                Strings.splitStringByCommaToArray(request.param("index")));
 
         if (request.hasParam("ignore_indices")) {
             searchIntoRequest.ignoreIndices(IgnoreIndices.fromString(
@@ -90,7 +90,7 @@ public class RestSearchIntoAction extends BaseRestHandler {
                 }
             }
             searchIntoRequest.routing(request.param("routing"));
-            searchIntoRequest.types(splitTypes(request.param("type")));
+            searchIntoRequest.types(Strings.splitStringByCommaToArray(request.param("type")));
             searchIntoRequest.preference(request.param("preference",
                     "_primary"));
         } catch (Exception e) {

--- a/src/main/java/crate/elasticsearch/script/IScriptContext.java
+++ b/src/main/java/crate/elasticsearch/script/IScriptContext.java
@@ -1,0 +1,29 @@
+package crate.elasticsearch.script;
+
+import java.util.Map;
+
+import org.elasticsearch.script.ExecutableScript;
+
+public interface IScriptContext {
+
+	void scriptString(String scriptString);
+	
+	void scriptLang(String scriptLang);
+	
+	void scriptParams(Map<String, Object> scriptParams);
+	
+	void executableScript(ExecutableScript executableScript);
+	
+	void executionContext(Map<String, Object> executionContext);
+	
+	public String scriptString();
+    
+    public String scriptLang();
+
+    public Map<String, Object> scriptParams();
+    
+    ExecutableScript executableScript();
+    
+    Map<String, Object> executionContext();
+    
+}

--- a/src/main/java/crate/elasticsearch/script/ScriptLangParseElement.java
+++ b/src/main/java/crate/elasticsearch/script/ScriptLangParseElement.java
@@ -1,0 +1,18 @@
+package crate.elasticsearch.script;
+
+
+import org.elasticsearch.common.xcontent.XContentParser;
+
+public class ScriptLangParseElement implements ScriptParseElement {
+
+    @Override
+    public void parse(XContentParser parser, IScriptContext context)
+            throws Exception {
+        XContentParser.Token token = parser.currentToken();
+        if (token.isValue()) {
+            context.scriptLang(parser.text());
+        }
+
+    }
+
+}

--- a/src/main/java/crate/elasticsearch/script/ScriptParamsParseElement.java
+++ b/src/main/java/crate/elasticsearch/script/ScriptParamsParseElement.java
@@ -1,0 +1,20 @@
+package crate.elasticsearch.script;
+
+import org.elasticsearch.common.xcontent.XContentParser;
+
+
+public class ScriptParamsParseElement implements ScriptParseElement {
+
+    @Override
+    public void parse(XContentParser parser, IScriptContext context)
+            throws Exception {
+        XContentParser.Token token = parser.currentToken();
+        if (token.isValue()) {
+            context.scriptParams(parser.map());
+        }
+
+    }
+
+	
+
+}

--- a/src/main/java/crate/elasticsearch/script/ScriptParseElement.java
+++ b/src/main/java/crate/elasticsearch/script/ScriptParseElement.java
@@ -1,0 +1,8 @@
+package crate.elasticsearch.script;
+
+import org.elasticsearch.common.xcontent.XContentParser;
+
+public interface ScriptParseElement {
+
+	void parse(XContentParser parser, IScriptContext context) throws Exception;
+}

--- a/src/main/java/crate/elasticsearch/script/ScriptParser.java
+++ b/src/main/java/crate/elasticsearch/script/ScriptParser.java
@@ -1,0 +1,26 @@
+package crate.elasticsearch.script;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.elasticsearch.common.collect.ImmutableMap;
+
+
+public class ScriptParser {
+
+	 private ImmutableMap<String, ScriptParseElement> scriptElementParsers;
+	 
+	 public ScriptParser() {
+	        Map<String, ScriptParseElement> scriptElementParsers = new HashMap<String, ScriptParseElement>();
+	        scriptElementParsers.put("script", new ScriptStringParseElement());
+	        scriptElementParsers.put("lang", new ScriptLangParseElement());
+	        scriptElementParsers.put("params", new ScriptParamsParseElement());
+	        this.scriptElementParsers = ImmutableMap.copyOf(scriptElementParsers);
+	    }
+
+	public ImmutableMap<String, ScriptParseElement> scriptElementParsers() {
+		return scriptElementParsers;
+	}
+	 
+	 
+}

--- a/src/main/java/crate/elasticsearch/script/ScriptProvider.java
+++ b/src/main/java/crate/elasticsearch/script/ScriptProvider.java
@@ -1,0 +1,20 @@
+package crate.elasticsearch.script;
+
+import org.elasticsearch.script.ExecutableScript;
+import org.elasticsearch.script.ScriptService;
+
+import java.util.Map;
+
+public class ScriptProvider {
+
+    public IScriptContext prepareContextForScriptExecution(IScriptContext context, ScriptService scriptService) {
+        String scriptString = context.scriptString();
+        String scriptLang = context.scriptLang();
+        Map<String, Object> scriptParams = context.scriptParams();
+        if (context.scriptString() != null) {
+            ExecutableScript executableScript = scriptService.executable(scriptLang, scriptString, scriptParams);
+            context.executableScript(executableScript);
+        }
+        return context;
+    }
+}

--- a/src/main/java/crate/elasticsearch/script/ScriptStringParseElement.java
+++ b/src/main/java/crate/elasticsearch/script/ScriptStringParseElement.java
@@ -1,0 +1,24 @@
+package crate.elasticsearch.script;
+
+import org.elasticsearch.common.logging.ESLogger;
+import org.elasticsearch.common.logging.ESLoggerFactory;
+import org.elasticsearch.common.xcontent.XContentParser;
+
+public class ScriptStringParseElement implements ScriptParseElement {
+
+	protected final ESLogger logger = ESLoggerFactory.getLogger(this.getClass().getName());
+
+	
+    @Override
+    public void parse(XContentParser parser, IScriptContext context)
+            throws Exception {
+        XContentParser.Token token = parser.currentToken();
+        if (token.isValue()) {
+        	String content = parser.text();
+        	logger.info("Added script into the context: " + content);
+            context.scriptString(content);
+        }
+
+    }
+
+}

--- a/src/main/java/crate/elasticsearch/searchinto/BulkWriterCollector.java
+++ b/src/main/java/crate/elasticsearch/searchinto/BulkWriterCollector.java
@@ -2,6 +2,7 @@ package crate.elasticsearch.searchinto;
 
 import crate.elasticsearch.action.searchinto.SearchIntoContext;
 import org.elasticsearch.ElasticSearchException;
+import org.elasticsearch.ElasticSearchIllegalArgumentException;
 import org.elasticsearch.action.bulk.BulkItemResponse;
 import org.elasticsearch.action.bulk.BulkProcessor;
 import org.elasticsearch.action.bulk.BulkRequest;
@@ -12,7 +13,7 @@ import org.elasticsearch.client.transport.TransportClient;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.inject.assistedinject.Assisted;
 import org.elasticsearch.common.logging.ESLogger;
-import org.elasticsearch.common.logging.Loggers;
+import org.elasticsearch.common.logging.ESLoggerFactory;
 import org.elasticsearch.common.settings.ImmutableSettings;
 import org.elasticsearch.common.transport.InetSocketTransportAddress;
 import org.elasticsearch.common.transport.TransportAddress;
@@ -27,14 +28,14 @@ import org.elasticsearch.search.fetch.version.VersionFetchSubPhase;
 
 import java.io.IOException;
 import java.util.Iterator;
+import java.util.Map;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.atomic.AtomicLong;
 
 public class BulkWriterCollector extends WriterCollector {
 
 
-    private static final ESLogger logger = Loggers.getLogger(
-            BulkWriterCollector.class);
+	protected final ESLogger logger = ESLoggerFactory.getLogger(this.getClass().getName());
 
     private Client client;
     private Client transportClient;
@@ -168,7 +169,6 @@ public class BulkWriterCollector extends WriterCollector {
 
     @Override
     public void close() throws WriterException {
-        logger.debug("close()");
         try {
             bulkProcessor.close();
         } catch (ElasticSearchException e) {
@@ -204,8 +204,64 @@ public class BulkWriterCollector extends WriterCollector {
     @Override
     public void collectHit(SearchHit hit) throws IOException {
         mappedFields.hit(hit);
-        IndexRequest req = mappedFields.newIndexRequest();
-        bulkProcessor.add(req);
+        IndexRequest indexRequest = mappedFields.newIndexRequest();
+        
+        // here we hook scripts
+        if(context.scriptString()!=null){
+        	Map<String, Object> map = indexRequest.sourceAsMap();
+            context.executionContext().clear();
+            context.executionContext().put("_index", indexRequest.index());
+            context.executionContext().put("_type", indexRequest.type());
+            context.executionContext().put("_id", indexRequest.id());
+            context.executionContext().put("_version", indexRequest.version());
+            context.executionContext().put("_source", map);
+            context.executionContext().put("_routing", indexRequest.routing());
+            context.executionContext().put("_parent", indexRequest.parent());
+            context.executionContext().put("_timestamp", indexRequest.timestamp());
+            context.executionContext().put("_ttl", indexRequest.ttl());
 
+            try {
+            	context.executableScript().setNextVar("ctx", context.executionContext());
+            	context.executableScript().run();
+                // we need to unwrap the ctx...
+            	context.executionContext().putAll((Map<String, Object>) context.executableScript().unwrap(context.executionContext()));
+                indexRequest.source(map);
+
+                String operation = (String) context.executionContext().get("op");
+                if (!(operation == null || "index".equals(operation)))  {
+                	// delete or unknown request - do not index this item
+                	indexRequest = null;
+                }
+                Object fetchedTimestamp = context.executionContext().get("_timestamp");
+                if (fetchedTimestamp != null) {
+                    if (fetchedTimestamp instanceof String) {
+                        indexRequest.timestamp(String.valueOf(TimeValue.parseTimeValue((String) fetchedTimestamp, null).millis()));
+                    } else {
+                        indexRequest.timestamp(fetchedTimestamp.toString());
+                    }
+                }
+                Object fetchedTTL = context.executionContext().get("_ttl");
+                if (fetchedTTL != null) {
+                    Long newTtl = -1L;
+                    if (fetchedTTL instanceof Number) {
+                         newTtl = ((Number) fetchedTTL).longValue();
+
+                    } else {
+                        newTtl = TimeValue.parseTimeValue((String) fetchedTTL, null).millis();
+                    }
+                    if (newTtl > 0) {
+                        indexRequest.ttl(newTtl);
+                    }
+                }
+
+            } catch (Exception e) {
+                throw new ElasticSearchIllegalArgumentException("failed to execute script", e);
+            }
+        }
+        
+        // end of hook
+        if(indexRequest!=null) { 
+           bulkProcessor.add(indexRequest);
+        }
     }
 }

--- a/src/main/java/crate/elasticsearch/searchinto/WriterCollector.java
+++ b/src/main/java/crate/elasticsearch/searchinto/WriterCollector.java
@@ -7,6 +7,9 @@ import org.apache.lucene.index.IndexReader;
 import org.apache.lucene.search.Collector;
 import org.apache.lucene.search.Scorer;
 import org.elasticsearch.common.inject.Inject;
+import org.elasticsearch.common.logging.ESLogger;
+import org.elasticsearch.common.logging.ESLoggerFactory;
+import org.elasticsearch.common.logging.Loggers;
 import org.elasticsearch.common.text.StringAndBytesText;
 import org.elasticsearch.common.text.Text;
 import org.elasticsearch.index.fieldvisitor.*;
@@ -27,6 +30,8 @@ import static org.elasticsearch.common.collect.Lists.newArrayList;
 
 public abstract class WriterCollector extends Collector {
 
+	protected final ESLogger logger = ESLoggerFactory.getLogger(this.getClass().getName());
+    
     private List<String> extractFieldNames;
     protected FieldsVisitor fieldsVisitor;
     protected SearchIntoContext context;

--- a/src/test/java/crate/elasticsearch/module/import_/test/RestImportActionTest.java
+++ b/src/test/java/crate/elasticsearch/module/import_/test/RestImportActionTest.java
@@ -11,7 +11,6 @@ import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
 import java.util.Map;
-
 import org.elasticsearch.action.admin.cluster.state.ClusterStateRequest;
 import org.elasticsearch.action.get.GetRequestBuilder;
 import org.elasticsearch.action.get.GetResponse;
@@ -19,7 +18,10 @@ import org.elasticsearch.client.Requests;
 import org.elasticsearch.cluster.metadata.IndexMetaData;
 import org.elasticsearch.cluster.metadata.MappingMetaData;
 import org.elasticsearch.common.collect.ImmutableMap;
+import org.elasticsearch.common.logging.ESLogger;
+import org.elasticsearch.common.logging.ESLoggerFactory;
 import org.junit.Test;
+
 
 import crate.elasticsearch.action.export.ExportAction;
 import crate.elasticsearch.action.export.ExportRequest;
@@ -31,6 +33,9 @@ import crate.elasticsearch.module.AbstractRestActionTest;
 
 public class RestImportActionTest extends AbstractRestActionTest {
 
+	//private final static Logger logger = Logger.getLogger(RestImportActionTest.class);
+	protected final ESLogger logger = ESLoggerFactory.getLogger(this.getClass().getName());
+	
     /**
      * An import directory must be specified in the post data of the request, otherwise
      * an 'No directory defined' exception is delivered in the output.
@@ -84,17 +89,107 @@ public class RestImportActionTest extends AbstractRestActionTest {
     }
 
     /**
+     * Test import using a script tag to modify field
+     */
+    @Test
+    public void testImportWithScriptElementModifyingField() {
+        String path = getClass().getResource("/importdata/import_2").getPath();
+
+        ImportResponse response = executeImportRequest("test","d","{\"directory\": \"" + path + "\", \"script\": \"ctx._source.name += ' scripted'; \"}");
+        List<Map<String, Object>> imports = getImports(response);
+        Map<String, Object> nodeInfo = imports.get(0);
+        assertTrue(nodeInfo.get("imported_files").toString().matches(
+                "\\[\\{file_name=(.*)/importdata/import_2/import_2.json, successes=4, failures=0\\}\\]"));
+        assertTrue(existsWithField("202", "name", "202 scripted"));
+        assertTrue(existsWithField("203", "name", "203 scripted"));
+        assertTrue(existsWithField("204", "name", "204 scripted"));
+        assertTrue(existsWithField("205", "name", "205 scripted"));
+    }
+
+    /**
+     * Test import using a script tag to add field
+     */
+    @Test
+    public void testImportWithScriptElementAddingField() {
+        String path = getClass().getResource("/importdata/import_2").getPath();
+        ImportResponse response = executeImportRequest("test","d", "{\"directory\": \"" + path + "\", \"script\": \"ctx._source.name2 = ctx._source.name + ' scripted'; \"}");
+        List<Map<String, Object>> imports = getImports(response);
+        Map<String, Object> nodeInfo = imports.get(0);
+        assertTrue(nodeInfo.get("imported_files").toString().matches(
+                "\\[\\{file_name=(.*)/importdata/import_2/import_2.json, successes=4, failures=0\\}\\]"));
+        assertTrue(existsWithField("202", "name", "202"));
+        assertTrue(existsWithField("203", "name", "203"));
+        assertTrue(existsWithField("204", "name", "204"));
+        assertTrue(existsWithField("205", "name", "205"));
+        assertTrue(existsWithField("202", "name2", "202 scripted"));
+        assertTrue(existsWithField("203", "name2", "203 scripted"));
+        assertTrue(existsWithField("204", "name2", "204 scripted"));
+        assertTrue(existsWithField("205", "name2", "205 scripted"));
+    }
+
+    /**
+     * Test import using a script tag to modify timestamp and ttl
+     */
+    @Test
+    public void testImportWithScriptElementModifyingTimestampAndTtl() {
+        esSetup.execute(deleteAll(), createIndex("test").withSettings(
+                fromClassPath("essetup/settings/test_a.json")).withMapping("d",
+                "{\"d\": {\"_timestamp\": {\"enabled\": true, \"store\": \"yes\"}}}"));
+
+        long ts = System.currentTimeMillis();
+        long ttl = 60*60*1000;
+        long tenSecs = 10*1000;
+
+        String path = getClass().getResource("/importdata/import_4").getPath();
+        ImportResponse response = executeImportRequest("{\"directory\": \"" + path + "\",  \"script\": \"ctx._timestamp = "+ts+"L; ctx._ttl = '60m'; \"}");
+        List<Map<String, Object>> imports = getImports(response);
+        assertEquals(1, imports.size());
+        Map<String, Object> nodeInfo = imports.get(0);
+        assertNotNull(nodeInfo.get("node_id"));
+        assertTrue(Long.valueOf(nodeInfo.get("took").toString()) > 0);
+        assertTrue(nodeInfo.get("imported_files").toString().matches(
+                "\\[\\{file_name=(.*)/importdata/import_4/import_4.json, successes=2, failures=0, invalidated=1}]"));
+
+        GetRequestBuilder rb = new GetRequestBuilder(esSetup.client(), "test");
+
+        GetResponse res = rb.setType("d").setId("402").setFields("_ttl", "_timestamp").execute().actionGet();
+        assertEquals(ts, res.getField("_timestamp").getValue());
+        assertTrue(ttl > ((Number)res.getField("_ttl").getValue()).longValue());
+        assertTrue(ttl - ((Number)res.getField("_ttl").getValue()).longValue() < tenSecs);
+
+        res = rb.setType("d").setId("403").setFields("_ttl", "_timestamp").execute().actionGet();
+        assertEquals(ts, res.getField("_timestamp").getValue());
+        assertTrue(ttl > ((Number)res.getField("_ttl").getValue()).longValue());
+        assertTrue(ttl - ((Number)res.getField("_ttl").getValue()).longValue() < tenSecs);
+    }
+
+
+    /**
+     * Test import using a script tag to delete a record
+     */
+    @Test
+    public void testImportWithScriptElementDeletingRecord() {
+        String path = getClass().getResource("/importdata/import_2").getPath();
+        ImportResponse response = executeImportRequest("test","d","{\"directory\": \"" + path + "\", \"script\": \"if (ctx._id == '204') ctx.op = 'delete'; \"}");
+        List<Map<String, Object>> imports = getImports(response);
+        Map<String, Object> nodeInfo = imports.get(0);
+        assertTrue(nodeInfo.get("imported_files").toString().matches(
+                "\\[\\{file_name=(.*)/importdata/import_2/import_2.json, successes=3, failures=0, deletes=1\\}\\]"));
+        assertTrue(existsWithField("202", "name", "202"));
+        assertTrue(existsWithField("203", "name", "203"));
+        assertFalse(exists("204"));
+        assertTrue(existsWithField("205", "name", "205"));
+    }
+
+    /**
      * If the index and/or type are given in the URI, all objects are imported
      * into the given index/type.
      */
     @Test
     public void testImportIntoIndexAndType() {
         String path = getClass().getResource("/importdata/import_2").getPath();
-        ImportRequest request = new ImportRequest();
-        request.index("another_index");
-        request.type("e");
-        request.source("{\"directory\": \"" + path + "\"}");
-        ImportResponse response = esSetup.client().execute(ImportAction.INSTANCE, request).actionGet();
+
+        ImportResponse response = executeImportRequest("another_index", "e", "{\"directory\": \"" + path + "\"}");
 
         List<Map<String, Object>> imports = getImports(response);
         Map<String, Object> nodeInfo = imports.get(0);
@@ -371,6 +466,16 @@ public class RestImportActionTest extends AbstractRestActionTest {
         return res.isExists() && res.getSourceAsMap().get(field).equals(value);
     }
 
+    private boolean exists(String id) {
+        return exists(id, "test", "d");
+    }
+
+    private boolean exists(String id, String index, String type) {
+        GetRequestBuilder rb = new GetRequestBuilder(esSetup.client(), index);
+        GetResponse res = rb.setType(type).setId(id).execute().actionGet();
+        return res.isExists();
+    }
+
     private static List<Map<String, Object>> getImports(ImportResponse resp) {
         return get(resp, "imports");
     }
@@ -395,5 +500,14 @@ public class RestImportActionTest extends AbstractRestActionTest {
         request.source(source);
         return esSetup.client().execute(ImportAction.INSTANCE, request).actionGet();
     }
+
+    private ImportResponse executeImportRequest(String index, String type, String source) {
+        ImportRequest request = new ImportRequest();
+        request.index(index);
+        request.type(type);
+        request.source(source);
+        return esSetup.client().execute(ImportAction.INSTANCE, request).actionGet();
+    }
+
 
 }

--- a/src/test/python/reindex.rst
+++ b/src/test/python/reindex.rst
@@ -54,7 +54,7 @@ be closed first and then reopened::
     >>> post("/test/_close", {})
     {"ok":true,"acknowledged":true}
     >>> put("/test/_settings", {"analysis": {"analyzer": {"myan": {"type": "stop", "stopwords": ["nice"]}}}})
-    {"ok":true}
+    {"ok":true,"acknowledged":true}
     >>> post("/test/_open", {})
     {"ok":true,"acknowledged":true}
     >>> refresh()

--- a/src/test/resources/log4j.properties
+++ b/src/test/resources/log4j.properties
@@ -1,0 +1,15 @@
+log4j.rootLogger=error, stdout
+
+log4j.appender.stdout=org.apache.log4j.ConsoleAppender
+log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
+log4j.appender.stdout.layout.ConversionPattern=%t %d{ABSOLUTE} %5p %c{1}:%L - %m%n
+
+log4j.category.crate.elasticsearch=info
+
+log4j.category.org.elasticsearch.node=WARN
+log4j.category.org.elasticsearch.plugins=WARN
+log4j.category.org.elasticsearch.transport=WARN
+log4j.category.org.elasticsearch.cluster=WARN
+log4j.category.org.elasticsearch.http=WARN
+log4j.category.org.elasticsearch.discovery=WARN
+log4j.category.org.elasticsearch.gateway=WARN


### PR DESCRIPTION
Added scripting support.  Can add script elements to modify data on reindex, query into, import, ...  Based on similar model in update by query.

This is applied to the other pull request for 1.0.0.beta1 compatibility, which was based on 0.90.3 branch.

Tests were added for scripting, documentation in the README is also updated.

A quick note, most of this pull request was written by Milan Agatonovic, but my merge squashed his commits into one with mine.
