### PR TITLE
update ElasticSearch to 0.90.10

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>crate</groupId>
 	<artifactId>elasticsearch-inout-plugin</artifactId>
-	<version>0.5.0</version>
+	<version>0.5.5</version>
     <packaging>jar</packaging>
     <description>An Elasticsearch plugin which provides the ability to export and import data by query on server side.</description>
     <scm>
@@ -14,7 +14,7 @@
         <url>https://github.com/crate/elasticsearch-inout-plugin</url>
     </scm>
 	<properties>
-		<elasticsearch.version>0.90.3</elasticsearch.version>
+		<elasticsearch.version>0.90.5</elasticsearch.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 	<build>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>crate</groupId>
 	<artifactId>elasticsearch-inout-plugin</artifactId>
-	<version>0.5.5</version>
+	<version>0.5.6</version>
     <packaging>jar</packaging>
     <description>An Elasticsearch plugin which provides the ability to export and import data by query on server side.</description>
     <scm>
@@ -14,7 +14,7 @@
         <url>https://github.com/crate/elasticsearch-inout-plugin</url>
     </scm>
 	<properties>
-		<elasticsearch.version>0.90.5</elasticsearch.version>
+		<elasticsearch.version>0.90.6</elasticsearch.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 	<build>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>crate</groupId>
 	<artifactId>elasticsearch-inout-plugin</artifactId>
-	<version>0.5.6</version>
+	<version>0.90.10</version>
     <packaging>jar</packaging>
     <description>An Elasticsearch plugin which provides the ability to export and import data by query on server side.</description>
     <scm>
@@ -14,7 +14,7 @@
         <url>https://github.com/crate/elasticsearch-inout-plugin</url>
     </scm>
 	<properties>
-		<elasticsearch.version>0.90.6</elasticsearch.version>
+		<elasticsearch.version>0.90.10</elasticsearch.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 	<build>

--- a/src/main/java/crate/elasticsearch/action/export/AbstractTransportExportAction.java
+++ b/src/main/java/crate/elasticsearch/action/export/AbstractTransportExportAction.java
@@ -149,7 +149,7 @@ public abstract class AbstractTransportExportAction extends TransportBroadcastOp
         SearchShardTarget shardTarget = new SearchShardTarget(clusterService.localNode().id(), request.index(), request.shardId());
         ExportContext context = new ExportContext(0,
             new ShardSearchRequest().types(request.types()).filteringAliases(request.filteringAliases()),
-            shardTarget, indexShard.searcher(), indexService, indexShard, scriptService, cacheRecycler, nodePath);
+            shardTarget, indexShard.acquireSearcher(), indexService, indexShard, scriptService, cacheRecycler, nodePath);
         ExportContext.setCurrent(context);
 
         try {

--- a/src/main/java/crate/elasticsearch/action/export/AbstractTransportExportAction.java
+++ b/src/main/java/crate/elasticsearch/action/export/AbstractTransportExportAction.java
@@ -149,7 +149,7 @@ public abstract class AbstractTransportExportAction extends TransportBroadcastOp
         SearchShardTarget shardTarget = new SearchShardTarget(clusterService.localNode().id(), request.index(), request.shardId());
         ExportContext context = new ExportContext(0,
             new ShardSearchRequest().types(request.types()).filteringAliases(request.filteringAliases()),
-            shardTarget, indexShard.acquireSearcher(), indexService, indexShard, scriptService, cacheRecycler, nodePath);
+            shardTarget, indexShard.acquireSearcher("inout-plugin"), indexService, indexShard, scriptService, cacheRecycler, nodePath);
         ExportContext.setCurrent(context);
 
         try {

--- a/src/main/java/crate/elasticsearch/action/export/ExportRequest.java
+++ b/src/main/java/crate/elasticsearch/action/export/ExportRequest.java
@@ -3,7 +3,6 @@ package crate.elasticsearch.action.export;
 import org.elasticsearch.action.ActionRequestValidationException;
 import org.elasticsearch.action.support.broadcast.BroadcastOperationRequest;
 import org.elasticsearch.common.Nullable;
-import org.elasticsearch.common.Required;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.bytes.BytesArray;
 import org.elasticsearch.common.bytes.BytesReference;
@@ -60,13 +59,11 @@ public class ExportRequest extends BroadcastOperationRequest<ExportRequest> {
         return source;
     }
 
-    @Required
     public ExportRequest source(String source) {
         return this.source(new BytesArray(source), false);
     }
 
 
-    @Required
     public ExportRequest source(BytesReference source, boolean unsafe) {
         this.source = source;
         this.querySourceUnsafe = unsafe;

--- a/src/main/java/crate/elasticsearch/action/import_/ImportRequest.java
+++ b/src/main/java/crate/elasticsearch/action/import_/ImportRequest.java
@@ -1,7 +1,6 @@
 package crate.elasticsearch.action.import_;
 
 import org.elasticsearch.action.support.nodes.NodesOperationRequest;
-import org.elasticsearch.common.Required;
 import org.elasticsearch.common.bytes.BytesArray;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.io.stream.StreamInput;
@@ -32,12 +31,10 @@ public class ImportRequest extends NodesOperationRequest<ImportRequest> {
         return source;
     }
 
-    @Required
     public ImportRequest source(String source) {
         return this.source(new BytesArray(source), false);
     }
 
-    @Required
     public ImportRequest source(BytesReference source, boolean unsafe) {
         this.source = source;
         return this;

--- a/src/main/java/crate/elasticsearch/action/searchinto/AbstractTransportSearchIntoAction.java
+++ b/src/main/java/crate/elasticsearch/action/searchinto/AbstractTransportSearchIntoAction.java
@@ -168,7 +168,7 @@ public abstract class AbstractTransportSearchIntoAction extends
                 request.shardId());
         SearchIntoContext context = new SearchIntoContext(0,
             new ShardSearchRequest().types(request.types()).filteringAliases(request.filteringAliases()),
-            shardTarget, indexShard.searcher(), indexService, indexShard, scriptService, cacheRecycler
+            shardTarget, indexShard.acquireSearcher(), indexService, indexShard, scriptService, cacheRecycler
         );
         SearchIntoContext.setCurrent(context);
 

--- a/src/main/java/crate/elasticsearch/action/searchinto/AbstractTransportSearchIntoAction.java
+++ b/src/main/java/crate/elasticsearch/action/searchinto/AbstractTransportSearchIntoAction.java
@@ -168,7 +168,7 @@ public abstract class AbstractTransportSearchIntoAction extends
                 request.shardId());
         SearchIntoContext context = new SearchIntoContext(0,
             new ShardSearchRequest().types(request.types()).filteringAliases(request.filteringAliases()),
-            shardTarget, indexShard.acquireSearcher(), indexService, indexShard, scriptService, cacheRecycler
+            shardTarget, indexShard.acquireSearcher("inout-plugin"), indexService, indexShard, scriptService, cacheRecycler
         );
         SearchIntoContext.setCurrent(context);
 

--- a/src/main/java/crate/elasticsearch/action/searchinto/SearchIntoRequest.java
+++ b/src/main/java/crate/elasticsearch/action/searchinto/SearchIntoRequest.java
@@ -3,7 +3,6 @@ package crate.elasticsearch.action.searchinto;
 import org.elasticsearch.action.ActionRequestValidationException;
 import org.elasticsearch.action.support.broadcast.BroadcastOperationRequest;
 import org.elasticsearch.common.Nullable;
-import org.elasticsearch.common.Required;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.bytes.BytesArray;
 import org.elasticsearch.common.bytes.BytesReference;
@@ -63,13 +62,11 @@ public class SearchIntoRequest extends
         return source;
     }
 
-    @Required
     public SearchIntoRequest source(String source) {
         return this.source(new BytesArray(source), false);
     }
 
 
-    @Required
     public SearchIntoRequest source(BytesReference source, boolean unsafe) {
         this.source = source;
         this.querySourceUnsafe = unsafe;

--- a/src/main/java/crate/elasticsearch/export/Exporter.java
+++ b/src/main/java/crate/elasticsearch/export/Exporter.java
@@ -9,6 +9,7 @@ import org.elasticsearch.client.Requests;
 import org.elasticsearch.cluster.metadata.IndexMetaData;
 import org.elasticsearch.cluster.metadata.MappingMetaData;
 import org.elasticsearch.cluster.metadata.MetaData;
+import org.elasticsearch.common.hppc.cursors.ObjectCursor;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.inject.Injector;
 import org.elasticsearch.common.logging.ESLogger;
@@ -159,10 +160,10 @@ public class Exporter {
                 builder.startObject(indexMetaData.index(), XContentBuilder.FieldCaseConversion.NONE);
                 Set<String> types = new HashSet<String>(Arrays.asList(context.types()));
                 boolean noTypes = types.isEmpty();
-                for (MappingMetaData mappingMetaData : indexMetaData.mappings().values()) {
-                    if (noTypes || types.contains(mappingMetaData.type())) {
-                        builder.field(mappingMetaData.type());
-                        builder.map(mappingMetaData.sourceAsMap());
+                for (ObjectCursor<MappingMetaData> mappingMetaData : indexMetaData.mappings().values()) {
+                    if (noTypes || types.contains(mappingMetaData.value.type())) {
+                        builder.field(mappingMetaData.value.type());
+                        builder.map(mappingMetaData.value.sourceAsMap());
                     }
                 }
                 builder.endObject();

--- a/src/main/java/crate/elasticsearch/rest/action/admin/export/RestExportAction.java
+++ b/src/main/java/crate/elasticsearch/rest/action/admin/export/RestExportAction.java
@@ -3,7 +3,6 @@ package crate.elasticsearch.rest.action.admin.export;
 import static org.elasticsearch.rest.RestRequest.Method.POST;
 import static org.elasticsearch.rest.RestStatus.BAD_REQUEST;
 import static org.elasticsearch.rest.RestStatus.OK;
-import static org.elasticsearch.rest.action.support.RestActions.splitTypes;
 
 import java.io.IOException;
 
@@ -12,6 +11,7 @@ import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.support.IgnoreIndices;
 import org.elasticsearch.action.support.broadcast.BroadcastOperationThreading;
 import org.elasticsearch.client.Client;
+import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.settings.Settings;
@@ -52,7 +52,7 @@ public class RestExportAction extends BaseRestHandler {
     }
 
     public void handleRequest(final RestRequest request, final RestChannel channel) {
-        ExportRequest exportRequest = new ExportRequest(RestActions.splitIndices(request.param("index")));
+        ExportRequest exportRequest = new ExportRequest(Strings.commaDelimitedListToStringArray(request.param("index")));
 
         if (request.hasParam("ignore_indices")) {
             exportRequest.ignoreIndices(IgnoreIndices.fromString(request.param("ignore_indices")));
@@ -79,7 +79,7 @@ public class RestExportAction extends BaseRestHandler {
                 }
             }
             exportRequest.routing(request.param("routing"));
-            exportRequest.types(splitTypes(request.param("type")));
+            exportRequest.types(Strings.commaDelimitedListToStringArray(request.param("type")));
             exportRequest.preference(request.param("preference", "_primary"));
         } catch (Exception e) {
             try {

--- a/src/main/java/crate/elasticsearch/rest/action/admin/searchinto/RestSearchIntoAction.java
+++ b/src/main/java/crate/elasticsearch/rest/action/admin/searchinto/RestSearchIntoAction.java
@@ -3,7 +3,6 @@ package crate.elasticsearch.rest.action.admin.searchinto;
 import static org.elasticsearch.rest.RestRequest.Method.POST;
 import static org.elasticsearch.rest.RestStatus.BAD_REQUEST;
 import static org.elasticsearch.rest.RestStatus.OK;
-import static org.elasticsearch.rest.action.support.RestActions.splitTypes;
 
 import java.io.IOException;
 
@@ -12,6 +11,7 @@ import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.support.IgnoreIndices;
 import org.elasticsearch.action.support.broadcast.BroadcastOperationThreading;
 import org.elasticsearch.client.Client;
+import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.settings.Settings;
@@ -55,7 +55,7 @@ public class RestSearchIntoAction extends BaseRestHandler {
     public void handleRequest(final RestRequest request,
             final RestChannel channel) {
         SearchIntoRequest searchIntoRequest = new SearchIntoRequest(
-                RestActions.splitIndices(request.param("index")));
+                Strings.commaDelimitedListToStringArray(request.param("index")));
 
         if (request.hasParam("ignore_indices")) {
             searchIntoRequest.ignoreIndices(IgnoreIndices.fromString(
@@ -90,7 +90,7 @@ public class RestSearchIntoAction extends BaseRestHandler {
                 }
             }
             searchIntoRequest.routing(request.param("routing"));
-            searchIntoRequest.types(splitTypes(request.param("type")));
+            searchIntoRequest.types(Strings.commaDelimitedListToStringArray(request.param("type")));
             searchIntoRequest.preference(request.param("preference",
                     "_primary"));
         } catch (Exception e) {

--- a/src/test/java/crate/elasticsearch/module/export/test/RestExportActionTest.java
+++ b/src/test/java/crate/elasticsearch/module/export/test/RestExportActionTest.java
@@ -610,9 +610,9 @@ public class RestExportActionTest extends AbstractRestActionTest {
         List<Map<String, Object>> infos = getExports(response);
         assertEquals(2, infos.size());
         String mappings_0 = new BufferedReader(new FileReader(new File(filename_0))).readLine();
-        assertEquals("{\"users\":{\"d\":{\"properties\":{\"name\":{\"type\":\"string\",\"index\":\"not_analyzed\",\"store\":true,\"omit_norms\":true,\"index_options\":\"docs\"}}}}}", mappings_0);
+        assertEquals("{\"users\":{\"d\":{\"properties\":{\"name\":{\"type\":\"string\",\"index\":\"not_analyzed\",\"store\":true,\"norms\":{\"enabled\":false},\"index_options\":\"docs\"}}}}}", mappings_0);
         String mappings_1 = new BufferedReader(new FileReader(new File(filename_1))).readLine();
-        assertEquals("{\"users\":{\"d\":{\"properties\":{\"name\":{\"type\":\"string\",\"index\":\"not_analyzed\",\"store\":true,\"omit_norms\":true,\"index_options\":\"docs\"}}}}}", mappings_1);
+        assertEquals("{\"users\":{\"d\":{\"properties\":{\"name\":{\"type\":\"string\",\"index\":\"not_analyzed\",\"store\":true,\"norms\":{\"enabled\":false},\"index_options\":\"docs\"}}}}}", mappings_1);
     }
 
     @Test

--- a/src/test/java/crate/elasticsearch/module/import_/test/RestImportActionTest.java
+++ b/src/test/java/crate/elasticsearch/module/import_/test/RestImportActionTest.java
@@ -19,6 +19,7 @@ import org.elasticsearch.client.Requests;
 import org.elasticsearch.cluster.metadata.IndexMetaData;
 import org.elasticsearch.cluster.metadata.MappingMetaData;
 import org.elasticsearch.common.collect.ImmutableMap;
+import org.elasticsearch.common.collect.ImmutableOpenMap;
 import org.junit.Test;
 
 import crate.elasticsearch.action.export.ExportAction;
@@ -326,8 +327,7 @@ public class RestImportActionTest extends AbstractRestActionTest {
         executeImportRequest("{\"directory\": \"" + path + "\", \"mappings\": true}");
 
         ClusterStateRequest clusterStateRequest = Requests.clusterStateRequest().filteredIndices("index1");
-        ImmutableMap<String, MappingMetaData> mappings = ImmutableMap.copyOf(
-            esSetup.client().admin().cluster().state(clusterStateRequest).actionGet().getState().metaData().index("index1").getMappings());
+        ImmutableOpenMap<String, MappingMetaData> mappings = esSetup.client().admin().cluster().state(clusterStateRequest).actionGet().getState().metaData().index("index1").getMappings();
         assertEquals("{\"1\":{\"_timestamp\":{\"enabled\":true,\"store\":true},\"_ttl\":{\"enabled\":true,\"default\":86400000},\"properties\":{\"name\":{\"type\":\"string\",\"store\":true}}}}",
                 mappings.get("1").source().toString());
     }

--- a/src/test/java/crate/elasticsearch/module/restore/test/RestRestoreActionTest.java
+++ b/src/test/java/crate/elasticsearch/module/restore/test/RestRestoreActionTest.java
@@ -71,7 +71,7 @@ public class RestRestoreActionTest extends AbstractRestActionTest {
 
         ClusterStateRequest clusterStateRequest = Requests.clusterStateRequest().filteredIndices("users");
         IndexMetaData metaData = esSetup.client().admin().cluster().state(clusterStateRequest).actionGet().getState().metaData().index("users");
-        assertEquals("{\"d\":{\"properties\":{\"name\":{\"type\":\"string\",\"index\":\"not_analyzed\",\"store\":true,\"omit_norms\":true,\"index_options\":\"docs\"}}}}",
+        assertEquals("{\"d\":{\"properties\":{\"name\":{\"type\":\"string\",\"index\":\"not_analyzed\",\"store\":true,\"norms\":{\"enabled\":false},\"index_options\":\"docs\"}}}}",
                 metaData.mappings().get("d").source().toString());
         assertEquals(2, metaData.numberOfShards());
         assertEquals(0, metaData.numberOfReplicas());

--- a/src/test/python/reindex.rst
+++ b/src/test/python/reindex.rst
@@ -54,7 +54,7 @@ be closed first and then reopened::
     >>> post("/test/_close", {})
     {"ok":true,"acknowledged":true}
     >>> put("/test/_settings", {"analysis": {"analyzer": {"myan": {"type": "stop", "stopwords": ["nice"]}}}})
-    {"ok":true}
+    {"ok":true,"acknowledged":true}
     >>> post("/test/_open", {})
     {"ok":true,"acknowledged":true}
     >>> refresh()


### PR DESCRIPTION
update to ElasticSearch 0.90.10, with API changes for collection classes, fix test cases for new norms response in mappings, and change version number of plugin to match ES version number.
